### PR TITLE
Fix uncaught exception handling invalid command

### DIFF
--- a/src/main/java/seedu/duke/command/InvalidCommand.java
+++ b/src/main/java/seedu/duke/command/InvalidCommand.java
@@ -1,8 +1,10 @@
 package seedu.duke.command;
 
 public class InvalidCommand extends Command {
+    static final String INVALID_MSG = "The command you returned is not understood";
+
     @Override
     public CommandResult executeCommand() throws Exception {
-        return null;
+        return new CommandResult(INVALID_MSG, false, false);
     }
 }


### PR DESCRIPTION
When the command is not understood, null was returned as the result, which results in getMessage() failing in NullPointerException.