### PR TITLE
Branch filter list feature

### DIFF
--- a/src/main/java/seedu/duke/command/ListCommand.java
+++ b/src/main/java/seedu/duke/command/ListCommand.java
@@ -2,6 +2,8 @@ package seedu.duke.command;
 
 import java.util.HashMap;
 import seedu.duke.exception.EmptyTasklistException;
+import seedu.duke.exception.ListFormatException;
+import seedu.duke.exception.MissingFilterArgumentException;
 import seedu.duke.task.TaskManager;
 
 public class ListCommand extends Command {
@@ -17,8 +19,12 @@ public class ListCommand extends Command {
 
         try {
             message = TaskManager.listTasklist(commandArguments);
-        } catch (EmptyTasklistException e) {
-            message = e.toString();
+        } catch (EmptyTasklistException ete) {
+            message = ete.toString();
+        } catch (ListFormatException lfe) {
+            message = lfe.toString();
+        } catch (MissingFilterArgumentException mfae) {
+            message = mfae.toString();
         }
 
         return new CommandResult(message, false, false);

--- a/src/main/java/seedu/duke/command/ListCommand.java
+++ b/src/main/java/seedu/duke/command/ListCommand.java
@@ -4,8 +4,6 @@ import java.util.HashMap;
 import seedu.duke.exception.EmptyTasklistException;
 import seedu.duke.task.TaskManager;
 
-import java.util.Map;
-
 public class ListCommand extends Command {
     private static final CommandEnum COMMAND = CommandEnum.LIST;
 
@@ -14,11 +12,11 @@ public class ListCommand extends Command {
     }
 
     @Override
-    public CommandResult executeCommand() throws Exception {
+    public CommandResult executeCommand() {
         String message = "";
 
         try {
-            message = TaskManager.listTasklist();
+            message = TaskManager.listTasklist(commandArguments);
         } catch (EmptyTasklistException e) {
             message = e.toString();
         }

--- a/src/main/java/seedu/duke/command/flags/ListFlag.java
+++ b/src/main/java/seedu/duke/command/flags/ListFlag.java
@@ -1,0 +1,9 @@
+package seedu.duke.command.flags;
+
+import seedu.duke.command.Command;
+
+public class ListFlag {
+    public static final String TASK_TYPE = "type";
+    public static final String PRIORITY = "priority";
+    public static final String RECURRENCE = "recur";
+}

--- a/src/main/java/seedu/duke/exception/ListFormatException.java
+++ b/src/main/java/seedu/duke/exception/ListFormatException.java
@@ -1,0 +1,13 @@
+package seedu.duke.exception;
+
+public class ListFormatException extends Exception {
+
+    private static final String MESSAGE = "[!] Your list command is wrong...\n"
+            + "Please follow the format: list or list --[type, priority, recur]";
+
+    @Override
+    public String toString() {
+        return MESSAGE;
+    }
+
+}

--- a/src/main/java/seedu/duke/exception/ListFormatException.java
+++ b/src/main/java/seedu/duke/exception/ListFormatException.java
@@ -2,8 +2,8 @@ package seedu.duke.exception;
 
 public class ListFormatException extends Exception {
 
-    private static final String MESSAGE = "[!] Your list command is wrong...\n"
-            + "Please follow the format: list or list --[type, priority, recur]";
+    private static final String MESSAGE = "[!] Your list command is using an invalid flag...\n"
+            + "Please follow the format: list or list --[type, priority, recur] <argument>";
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/duke/exception/MissingFilterArgumentException.java
+++ b/src/main/java/seedu/duke/exception/MissingFilterArgumentException.java
@@ -1,0 +1,13 @@
+package seedu.duke.exception;
+
+public class MissingFilterArgumentException extends Exception {
+
+    private static final String MESSAGE = "[!] One of your filter's is missing an argument...\n"
+            + "Please follow the format: list or list --[type, priority, recur] <argument>";
+
+    @Override
+    public String toString() {
+        return MESSAGE;
+    }
+
+}

--- a/src/main/java/seedu/duke/task/TaskManager.java
+++ b/src/main/java/seedu/duke/task/TaskManager.java
@@ -1,5 +1,6 @@
 package seedu.duke.task;
 
+import seedu.duke.command.flags.ListFlag;
 import seedu.duke.command.flags.SortFlag;
 import seedu.duke.exception.EmptySortCriteriaException;
 import seedu.duke.exception.EmptyTasklistException;
@@ -17,8 +18,12 @@ public class TaskManager {
 
     private static ArrayList<Task> taskList = new ArrayList<>(128);
 
+    private static final String LIST_HEADER = "-------------\n"
+            + " MY TASKLIST\n"
+            + "-------------\n";
+
     //@@author APZH
-    public static String listTasklist() throws EmptyTasklistException {
+    public static String listTasklist(HashMap<String, String> filter) throws EmptyTasklistException {
         Log.info("listTasklist method called");
         assert taskList.size() >= 0 : "Tasklist cannot be negative";
 
@@ -27,16 +32,65 @@ public class TaskManager {
             throw new EmptyTasklistException();
         }
 
-        String tasks = "-------------\n"
-                + " MY TASKLIST\n"
-                + "-------------\n";
+        String taskEntries = "";
 
-        for (int i = 0; i < taskList.size(); i++) {
-            tasks += i + 1 + ". " + taskList.get(i).getTaskEntryDescription() + "\n";
+        ArrayList<Task> filteredTasks = (ArrayList<Task>)taskList.clone();
+        for (HashMap.Entry<String, String> entry : filter.entrySet()) {
+            String flag = entry.getKey();
+            String argument = entry.getValue();
+            switch (flag) {
+            case ListFlag.TASK_TYPE:
+                filteredTasks = filterListByTaskType(filteredTasks, argument);
+                break;
+            case ListFlag.PRIORITY:
+                filteredTasks = filterListByPriority(filteredTasks, argument);
+                break;
+            case ListFlag.RECURRENCE:
+                filteredTasks = filterListByRecurrence(filteredTasks, argument);
+                break;
+            default:
+                continue;
+            }
         }
 
+        for (int i = 0; i < filteredTasks.size(); i++) {
+            taskEntries += i + 1 + ". " + filteredTasks.get(i).getTaskEntryDescription() + "\n";
+        }
         Log.info("end of listTasklist - no issues detected");
-        return tasks;
+        return LIST_HEADER + taskEntries;
+    }
+
+    public static ArrayList<Task> filterListByTaskType(ArrayList<Task> taskList, String taskTypeFilter) {
+        ArrayList<Task> filteredTasks = new ArrayList<>();
+        for (int i = 0; i < taskList.size(); i++) {
+            String currentTaskType = taskList.get(i).getTaskType().name();
+            if (currentTaskType.equalsIgnoreCase(taskTypeFilter)) {
+                filteredTasks.add(taskList.get(i));
+            }
+        }
+        return filteredTasks;
+    }
+
+    public static ArrayList<Task> filterListByPriority(ArrayList<Task> taskList, String priorityFilter) {
+        ArrayList<Task> filteredTasks = new ArrayList<>();
+        for (int i = 0; i < taskList.size(); i++) {
+            String currentPriority = taskList.get(i).getPriority().name();
+            if (currentPriority.equalsIgnoreCase(priorityFilter)) {
+                filteredTasks.add(taskList.get(i));
+            }
+        }
+        return filteredTasks;
+    }
+
+    public static ArrayList<Task> filterListByRecurrence(ArrayList<Task> taskList, String recurrenceFilter) {
+        ArrayList<Task> filteredTasks = new ArrayList<>();
+        for (int i = 0; i < taskList.size(); i++) {
+            String currentRecurrence = taskList.get(i).getRecurrence().name();
+            if (currentRecurrence.equalsIgnoreCase(recurrenceFilter)) {
+                filteredTasks.add(taskList.get(i));
+            }
+        }
+        return filteredTasks;
     }
 
     //@@author APZH
@@ -139,6 +193,15 @@ public class TaskManager {
 
     public static void addTask(Task task) {
         taskList.add(task);
+    }
+
+    private static void printArrayList(ArrayList<Task> filteredTasks) {
+        String tasks = "";
+        System.out.println("Printing filtered list...");
+        for (int i = 0; i < filteredTasks.size(); i++) {
+            tasks += i + 1 + ". " + filteredTasks.get(i).getTaskEntryDescription() + "\n";
+        }
+        System.out.println(tasks);
     }
 
 }

--- a/src/main/java/seedu/duke/task/TaskManager.java
+++ b/src/main/java/seedu/duke/task/TaskManager.java
@@ -4,6 +4,8 @@ import seedu.duke.command.flags.ListFlag;
 import seedu.duke.command.flags.SortFlag;
 import seedu.duke.exception.EmptySortCriteriaException;
 import seedu.duke.exception.EmptyTasklistException;
+import seedu.duke.exception.ListFormatException;
+import seedu.duke.exception.MissingFilterArgumentException;
 import seedu.duke.exception.SortFormatException;
 import seedu.duke.log.Log;
 
@@ -23,8 +25,8 @@ public class TaskManager {
             + "-------------\n";
 
     //@@author APZH
-    public static String listTasklist(HashMap<String, String> filter) throws EmptyTasklistException {
-        Log.info("listTasklist method called");
+    public static String listTasklist(HashMap<String, String> filter) throws EmptyTasklistException,
+            ListFormatException, MissingFilterArgumentException {
         assert taskList.size() >= 0 : "Tasklist cannot be negative";
 
         if (taskList.size() == 0) {
@@ -33,11 +35,14 @@ public class TaskManager {
         }
 
         String taskEntries = "";
+        ArrayList<Task> filteredTasks = (ArrayList<Task>) taskList.clone();
 
-        ArrayList<Task> filteredTasks = (ArrayList<Task>)taskList.clone();
         for (HashMap.Entry<String, String> entry : filter.entrySet()) {
             String flag = entry.getKey();
             String argument = entry.getValue();
+            if (flag.equals("mainArgument")) {
+                continue;
+            }
             switch (flag) {
             case ListFlag.TASK_TYPE:
                 filteredTasks = filterListByTaskType(filteredTasks, argument);
@@ -49,18 +54,21 @@ public class TaskManager {
                 filteredTasks = filterListByRecurrence(filteredTasks, argument);
                 break;
             default:
-                continue;
+                throw new ListFormatException();
             }
         }
 
         for (int i = 0; i < filteredTasks.size(); i++) {
             taskEntries += i + 1 + ". " + filteredTasks.get(i).getTaskEntryDescription() + "\n";
         }
-        Log.info("end of listTasklist - no issues detected");
         return LIST_HEADER + taskEntries;
     }
 
-    public static ArrayList<Task> filterListByTaskType(ArrayList<Task> taskList, String taskTypeFilter) {
+    public static ArrayList<Task> filterListByTaskType(ArrayList<Task> taskList, String taskTypeFilter)
+            throws MissingFilterArgumentException {
+        if (taskTypeFilter.isEmpty()) {
+            throw new MissingFilterArgumentException();
+        }
         ArrayList<Task> filteredTasks = new ArrayList<>();
         for (int i = 0; i < taskList.size(); i++) {
             String currentTaskType = taskList.get(i).getTaskType().name();
@@ -71,7 +79,11 @@ public class TaskManager {
         return filteredTasks;
     }
 
-    public static ArrayList<Task> filterListByPriority(ArrayList<Task> taskList, String priorityFilter) {
+    public static ArrayList<Task> filterListByPriority(ArrayList<Task> taskList, String priorityFilter)
+            throws MissingFilterArgumentException {
+        if (priorityFilter.isEmpty()) {
+            throw new MissingFilterArgumentException();
+        }
         ArrayList<Task> filteredTasks = new ArrayList<>();
         for (int i = 0; i < taskList.size(); i++) {
             String currentPriority = taskList.get(i).getPriority().name();
@@ -82,7 +94,11 @@ public class TaskManager {
         return filteredTasks;
     }
 
-    public static ArrayList<Task> filterListByRecurrence(ArrayList<Task> taskList, String recurrenceFilter) {
+    public static ArrayList<Task> filterListByRecurrence(ArrayList<Task> taskList, String recurrenceFilter)
+            throws MissingFilterArgumentException {
+        if (recurrenceFilter.isEmpty()) {
+            throw new MissingFilterArgumentException();
+        }
         ArrayList<Task> filteredTasks = new ArrayList<>();
         for (int i = 0; i < taskList.size(); i++) {
             String currentRecurrence = taskList.get(i).getRecurrence().name();
@@ -104,9 +120,9 @@ public class TaskManager {
             throw new EmptyTasklistException();
         }
         if (criteria.containsKey(SortFlag.SORT_BY)) {
-            Log.warning("user did not indicate 'by' flag, throwing SortFormatException");
             sortCriteria = criteria.get(SortFlag.SORT_BY);
         } else {
+            Log.warning("user did not indicate 'by' flag, throwing SortFormatException");
             throw new SortFormatException();
         }
         if (sortCriteria.isEmpty()) {

--- a/src/test/java/seedu/duke/task/TaskManagerTest.java
+++ b/src/test/java/seedu/duke/task/TaskManagerTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
 import seedu.duke.exception.EmptyTasklistException;
+import seedu.duke.exception.ListFormatException;
+import seedu.duke.exception.MissingFilterArgumentException;
 import seedu.duke.exception.ParseDateFailedException;
 import seedu.duke.parser.UtilityParser;
 import seedu.duke.task.type.Deadline;
@@ -40,8 +42,12 @@ class TaskManagerTest {
         try {
             System.out.println("Testing List Command");
             System.out.println(TaskManager.listTasklist(listArguments));
-        } catch (EmptyTasklistException e) {
-            System.out.println(e);
+        } catch (EmptyTasklistException ete) {
+            System.out.println(ete);
+        } catch (ListFormatException lfe) {
+            System.out.println(lfe);
+        } catch (MissingFilterArgumentException mfae) {
+            System.out.println(mfae);
         }
     }
 

--- a/src/test/java/seedu/duke/task/TaskManagerTest.java
+++ b/src/test/java/seedu/duke/task/TaskManagerTest.java
@@ -19,8 +19,8 @@ class TaskManagerTest {
     Task newToDo;
     Task newDeadline;
     Task newEvent;
-    private static final String VALID_DATE1 = "14-02-1998 02:00:00";
-    private static final String VALID_DATE2 = "14-02-1998 03:30:00";
+    private static final String VALID_DATE1 = "22-10-2021 02:00:00";
+    private static final String VALID_DATE2 = "22-10-2021 05:00:00";
 
     private TaskManagerTest() throws ParseDateFailedException {
         Date startDate = UtilityParser.getStringAsDate(VALID_DATE1);
@@ -35,9 +35,11 @@ class TaskManagerTest {
 
     @Test
     void testListTasklistFormat() {
+        HashMap<String, String> listArguments = new HashMap<>();
+        listArguments.put("random_flag", "random_criteria");
         try {
             System.out.println("Testing List Command");
-            System.out.println(TaskManager.listTasklist());
+            System.out.println(TaskManager.listTasklist(listArguments));
         } catch (EmptyTasklistException e) {
             System.out.println(e);
         }
@@ -46,13 +48,15 @@ class TaskManagerTest {
     @Test
     void testSortTasklistByPriority() {
 
-        HashMap<String, String> commandArguments = new HashMap<>();
-        commandArguments.put("by", "priority");
+        HashMap<String, String> sortArguments = new HashMap<>();
+        sortArguments.put("by", "priority");
+
+        HashMap<String, String> listArguments = new HashMap<>();
 
         try {
             System.out.println("Testing Sort by Priority Command");
-            TaskManager.sortTasklist(commandArguments);
-            System.out.println(TaskManager.listTasklist());
+            TaskManager.sortTasklist(sortArguments);
+            System.out.println(TaskManager.listTasklist(listArguments));
         } catch (Exception e) {
             System.out.println("Exception occurred");
         }
@@ -62,13 +66,15 @@ class TaskManagerTest {
     @Test
     void testSortTasklistByDescription() {
 
-        HashMap<String, String> commandArguments = new HashMap<>();
-        commandArguments.put("by", "description");
+        HashMap<String, String> sortArguments = new HashMap<>();
+        sortArguments.put("by", "description");
+
+        HashMap<String, String> listArguments = new HashMap<>();
 
         try {
             System.out.println("Testing Sort by Description Command");
-            TaskManager.sortTasklist(commandArguments);
-            System.out.println(TaskManager.listTasklist());
+            TaskManager.sortTasklist(sortArguments);
+            System.out.println(TaskManager.listTasklist(listArguments));
         } catch (Exception e) {
             System.out.println("Exception occurred");
         }
@@ -78,13 +84,15 @@ class TaskManagerTest {
     @Test
     void testSortTasklistByTaskType() {
 
-        HashMap<String, String> commandArguments = new HashMap<>();
-        commandArguments.put("by", "type");
+        HashMap<String, String> sortArguments = new HashMap<>();
+        sortArguments.put("by", "type");
+
+        HashMap<String, String> listArguments = new HashMap<>();
 
         try {
             System.out.println("Testing Sort by Task Type Command");
-            TaskManager.sortTasklist(commandArguments);
-            System.out.println(TaskManager.listTasklist());
+            TaskManager.sortTasklist(sortArguments);
+            System.out.println(TaskManager.listTasklist(listArguments));
         } catch (Exception e) {
             System.out.println("Exception occurred");
         }
@@ -94,11 +102,11 @@ class TaskManagerTest {
     @Test
     void sortTasklist_ThrowsException_IfMissingByFlag() {
 
-        HashMap<String, String> commandArguments = new HashMap<>();
-        commandArguments.put("random_flag", "random_criteria");
+        HashMap<String, String> sortArguments = new HashMap<>();
+        sortArguments.put("random_flag", "random_criteria");
 
         try {
-            TaskManager.sortTasklist(commandArguments);
+            TaskManager.sortTasklist(sortArguments);
             fail(); // the test should not reach here
         } catch (Exception e) {
             System.out.println("SortFormatException caught");


### PR DESCRIPTION
Added new filter flags to be processed by 'list' command that allows users to filter the tasklist up to 3 filtering options
-> Task Type, Priority, Reccurrence

Command Syntax -> list or list --[type, priority, recur] <argument>
- Do note that argument is consistent with the ENUMS of the said flags i.e. list --priority low --recur daily --type todo
- this filtering option allows for multi filtering
- *Drawback is that the displayed numbering is not tied to the index of the task in the actual tasklist

Added J-Unit testing and exception handling for this command.